### PR TITLE
fix space " max_connections")

### DIFF
--- a/roles/postgres/tasks/postgres.yml
+++ b/roles/postgres/tasks/postgres.yml
@@ -23,7 +23,7 @@
       POSTGRES_USER: "{{ postgres_user }}"
       POSTGRES_PASSWORD: "{{ postgres_password }}"
       POSTGRES_DB: "{{ postgres_db }}"
-    command: [postgres, -c, " max_connections={{ postgres_max_connections }}"]
+    command: [postgres, -c, "max_connections={{ postgres_max_connections }}"]
     volumes: "{{ postgres_volumes }}"
     ports: "{{ postgres_ports }}"
     networks:


### PR DESCRIPTION
The issue is caused by an extra space before the max_connections parameter (" max_connections") in the configuration, making it unrecognized